### PR TITLE
maint: Update proto definitions to v1.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 [![Build Check](https://github.com/open-telemetry/opentelemetry-proto/workflows/Build%20Check/badge.svg?branch=main)](https://github.com/open-telemetry/opentelemetry-proto/actions?query=workflow%3A%22Build+Check%22+branch%3Amain)
 
+⚠️ **NOTE** ⚠️
+
+This is a modified version of the Go OpenTelemtry protobuf files to re-add deprecated/removed Metric types (IntSum, IntGuage, IntHistogram) and label type (StringKeyValue).
+
+You should not depend on these protobuf files directly, instead use the Honeycomb fork of the [opentelemetry-proto-go](https://github.com/honeycombio/opentelemetry-proto-go) package which includes these changes.
+
+---
+
 This repository contains the [OTLP protocol specification](docs/specification.md)
 and the corresponding Language Independent Interface Types ([.proto files](opentelemetry/proto)).
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # Language Independent Interface Types For OpenTelemetry
 
+**NOTE**
+
+This is a modified version of the Go OpenTelemtry protobuf files to re-add deprecated/removed Metric types (IntSum, IntGuage, IntHistogram) and label type (StringKeyValue).
+
+You should not depend on these protobuf files directly, instead use the Honeycomb fork of the [opentelemetry-proto-go](https://github.com/honeycombio/opentelemetry-proto-go) package which includes these changes.
+
+This repo is currently pinned to [v0.19.0](https://github.com/open-telemetry/opentelemetry-proto/tree/v0.19.0) of the upstream repository.
+
 [![Build Check](https://github.com/open-telemetry/opentelemetry-proto/workflows/Build%20Check/badge.svg?branch=main)](https://github.com/open-telemetry/opentelemetry-proto/actions?query=workflow%3A%22Build+Check%22+branch%3Amain)
 
 The proto files can be consumed as GIT submodules or copied and built directly in the consumer project.

--- a/opentelemetry/proto/common/v1/common.proto
+++ b/opentelemetry/proto/common/v1/common.proto
@@ -66,8 +66,17 @@ message KeyValue {
   AnyValue value = 2;
 }
 
+// StringKeyValue is a pair of key/value strings. This is the simpler (and faster) version
+// of KeyValue that only supports string values.
+message StringKeyValue {
+  option deprecated = true;
+
+  string key = 1;
+  string value = 2;
+}
+
 // InstrumentationScope is a message representing the instrumentation scope information
-// such as the fully qualified name and version. 
+// such as the fully qualified name and version.
 message InstrumentationScope {
   // An empty instrumentation scope name means the name is unknown.
   string name = 1;

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -160,8 +160,6 @@ message ScopeMetrics {
 // when the start time is truly unknown, setting StartTimeUnixNano is
 // strongly encouraged.
 message Metric {
-  reserved 4, 6, 8;
-
   // name of the metric, including its DNS name prefix. It must be unique.
   string name = 1;
 
@@ -176,8 +174,28 @@ message Metric {
   // reported value type for the data points, as well as the relatationship to
   // the time interval over which they are reported.
   oneof data {
+    // IntGauge and IntSum are deprecated and will be removed soon.
+    // 1. Old senders and receivers that are not aware of this change will
+    // continue using the `int_gauge` and `int_sum` fields.
+    // 2. New senders, which are aware of this change MUST send only `gauge`
+    // and `sum` fields.
+    // 3. New receivers, which are aware of this change MUST convert these into
+    // `gauge` and `sum` by using the provided as_int field in the oneof values.
+    // This field will be removed in ~3 months, on July 1, 2021.
+    IntGauge int_gauge = 4 [deprecated = true];
     Gauge gauge = 5;
+    // This field will be removed in ~3 months, on July 1, 2021.
+    IntSum int_sum = 6 [deprecated = true];
     Sum sum = 7;
+
+    // IntHistogram is deprecated and will be removed soon.
+    // 1. Old senders and receivers that are not aware of this change will
+    // continue using the `int_histogram` field.
+    // 2. New senders, which are aware of this change MUST send only `histogram`.
+    // 3. New receivers, which are aware of this change MUST convert this into
+    // `histogram` by simply converting all int64 values into float.
+    // This field will be removed in ~3 months, on July 1, 2021.
+    IntHistogram int_histogram = 8 [deprecated = true];
     Histogram histogram = 9;
     ExponentialHistogram exponential_histogram = 10;
     Summary summary = 11;
@@ -332,13 +350,21 @@ enum DataPointFlags {
 // NumberDataPoint is a single data point in a timeseries that describes the
 // time-varying scalar value of a metric.
 message NumberDataPoint {
-  reserved 1;
-
   // The set of key/value pairs that uniquely identify the timeseries from
   // where this point belongs. The list may be empty (may contain 0 elements).
   // Attribute keys MUST be unique (it is not allowed to have more than one
   // attribute with the same key).
   repeated opentelemetry.proto.common.v1.KeyValue attributes = 7;
+
+  // Labels is deprecated and will be removed soon.
+  // 1. Old senders and receivers that are not aware of this change will
+  // continue using the `labels` field.
+  // 2. New senders, which are aware of this change MUST send only `attributes`.
+  // 3. New receivers, which are aware of this change MUST convert this into
+  // `labels` by simply converting all int64 values into float.
+  //
+  // This field will be removed in ~3 months, on July 1, 2021.
+  repeated opentelemetry.proto.common.v1.StringKeyValue labels = 1 [deprecated = true];
 
   // StartTimeUnixNano is optional but strongly encouraged, see the
   // the detailed comments above Metric.
@@ -380,13 +406,21 @@ message NumberDataPoint {
 // "explicit_bounds" and "bucket_counts" must be omitted and only "count" and
 // "sum" are known.
 message HistogramDataPoint {
-  reserved 1;
-
   // The set of key/value pairs that uniquely identify the timeseries from
   // where this point belongs. The list may be empty (may contain 0 elements).
   // Attribute keys MUST be unique (it is not allowed to have more than one
   // attribute with the same key).
   repeated opentelemetry.proto.common.v1.KeyValue attributes = 9;
+
+  // Labels is deprecated and will be removed soon.
+  // 1. Old senders and receivers that are not aware of this change will
+  // continue using the `labels` field.
+  // 2. New senders, which are aware of this change MUST send only `attributes`.
+  // 3. New receivers, which are aware of this change MUST convert this into
+  // `labels` by simply converting all int64 values into float.
+  //
+  // This field will be removed in ~3 months, on July 1, 2021.
+  repeated opentelemetry.proto.common.v1.StringKeyValue labels = 1 [deprecated = true];
 
   // StartTimeUnixNano is optional but strongly encouraged, see the
   // the detailed comments above Metric.
@@ -566,13 +600,21 @@ message ExponentialHistogramDataPoint {
 // SummaryDataPoint is a single data point in a timeseries that describes the
 // time-varying values of a Summary metric.
 message SummaryDataPoint {
-  reserved 1;
-
   // The set of key/value pairs that uniquely identify the timeseries from
   // where this point belongs. The list may be empty (may contain 0 elements).
   // Attribute keys MUST be unique (it is not allowed to have more than one
   // attribute with the same key).
   repeated opentelemetry.proto.common.v1.KeyValue attributes = 7;
+
+  // Labels is deprecated and will be removed soon.
+  // 1. Old senders and receivers that are not aware of this change will
+  // continue using the `labels` field.
+  // 2. New senders, which are aware of this change MUST send only `attributes`.
+  // 3. New receivers, which are aware of this change MUST convert this into
+  // `labels` by simply converting all int64 values into float.
+  //
+  // This field will be removed in ~3 months, on July 1, 2021.
+  repeated opentelemetry.proto.common.v1.StringKeyValue labels = 1 [deprecated = true];
 
   // StartTimeUnixNano is optional but strongly encouraged, see the
   // the detailed comments above Metric.
@@ -633,12 +675,21 @@ message SummaryDataPoint {
 // was recorded, for example the span and trace ID of the active span when the
 // exemplar was recorded.
 message Exemplar {
-  reserved 1;
-
   // The set of key/value pairs that were filtered out by the aggregator, but
   // recorded alongside the original measurement. Only key/value pairs that were
   // filtered out by the aggregator should be included
   repeated opentelemetry.proto.common.v1.KeyValue filtered_attributes = 7;
+
+  // Labels is deprecated and will be removed soon.
+  // 1. Old senders and receivers that are not aware of this change will
+  // continue using the `filtered_labels` field.
+  // 2. New senders, which are aware of this change MUST send only
+  // `filtered_attributes`.
+  // 3. New receivers, which are aware of this change MUST convert this into
+  // `filtered_labels` by simply converting all int64 values into float.
+  //
+  // This field will be removed in ~3 months, on July 1, 2021.
+  repeated opentelemetry.proto.common.v1.StringKeyValue filtered_labels = 1 [deprecated = true];
 
   // time_unix_nano is the exact time when this exemplar was recorded
   //
@@ -653,6 +704,159 @@ message Exemplar {
     double as_double = 3;
     sfixed64 as_int = 6;
   }
+
+  // (Optional) Span ID of the exemplar trace.
+  // span_id may be missing if the measurement is not recorded inside a trace
+  // or if the trace is not sampled.
+  bytes span_id = 4;
+
+  // (Optional) Trace ID of the exemplar trace.
+  // trace_id may be missing if the measurement is not recorded inside a trace
+  // or if the trace is not sampled.
+  bytes trace_id = 5;
+}
+
+//
+// Move deprecated messages below this line
+//
+
+// IntDataPoint is deprecated. Use integer value in NumberDataPoint.
+message IntDataPoint {
+  option deprecated = true;
+
+  // The set of labels that uniquely identify this timeseries.
+  repeated opentelemetry.proto.common.v1.StringKeyValue labels = 1;
+
+  // StartTimeUnixNano is optional but strongly encouraged, see the
+  // the detailed comments above Metric.
+  //
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+  // 1970.
+  fixed64 start_time_unix_nano = 2;
+
+  // TimeUnixNano is required, see the detailed comments above Metric.
+  //
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+  // 1970.
+  fixed64 time_unix_nano = 3;
+
+  // value itself.
+  sfixed64 value = 4;
+
+  // (Optional) List of exemplars collected from
+  // measurements that were used to form the data point
+  repeated IntExemplar exemplars = 5;
+}
+
+// IntGauge is deprecated.  Use Gauge with an integer value in NumberDataPoint.
+message IntGauge {
+  option deprecated = true;
+
+  repeated IntDataPoint data_points = 1;
+}
+
+// IntSum is deprecated.  Use Sum with an integer value in NumberDataPoint.
+message IntSum {
+  option deprecated = true;
+
+  repeated IntDataPoint data_points = 1;
+
+  // aggregation_temporality describes if the aggregator reports delta changes
+  // since last report time, or cumulative changes since a fixed start time.
+  AggregationTemporality aggregation_temporality = 2;
+
+  // If "true" means that the sum is monotonic.
+  bool is_monotonic = 3;
+}
+
+// IntHistogramDataPoint is deprecated; use HistogramDataPoint.
+message IntHistogramDataPoint {
+  option deprecated = true;
+
+  // The set of labels that uniquely identify this timeseries.
+  repeated opentelemetry.proto.common.v1.StringKeyValue labels = 1;
+
+  // StartTimeUnixNano is optional but strongly encouraged, see the
+  // the detailed comments above Metric.
+  //
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+  // 1970.
+  fixed64 start_time_unix_nano = 2;
+
+  // TimeUnixNano is required, see the detailed comments above Metric.
+  //
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+  // 1970.
+  fixed64 time_unix_nano = 3;
+
+  // count is the number of values in the population. Must be non-negative. This
+  // value must be equal to the sum of the "count" fields in buckets if a
+  // histogram is provided.
+  fixed64 count = 4;
+
+  // sum of the values in the population. If count is zero then this field
+  // must be zero. This value must be equal to the sum of the "sum" fields in
+  // buckets if a histogram is provided.
+  sfixed64 sum = 5;
+
+  // bucket_counts is an optional field contains the count values of histogram
+  // for each bucket.
+  //
+  // The sum of the bucket_counts must equal the value in the count field.
+  //
+  // The number of elements in bucket_counts array must be by one greater than
+  // the number of elements in explicit_bounds array.
+  repeated fixed64 bucket_counts = 6;
+
+  // explicit_bounds specifies buckets with explicitly defined bounds for values.
+  //
+  // The boundaries for bucket at index i are:
+  //
+  // (-infinity, explicit_bounds[i]] for i == 0
+  // (explicit_bounds[i-1], explicit_bounds[i]] for 0 < i < size(explicit_bounds)
+  // (explicit_bounds[i-1], +infinity) for i == size(explicit_bounds)
+  //
+  // The values in the explicit_bounds array must be strictly increasing.
+  //
+  // Histogram buckets are inclusive of their upper boundary, except the last
+  // bucket where the boundary is at infinity. This format is intentionally
+  // compatible with the OpenMetrics histogram definition.
+  repeated double explicit_bounds = 7;
+
+  // (Optional) List of exemplars collected from
+  // measurements that were used to form the data point
+  repeated IntExemplar exemplars = 8;
+}
+
+// IntHistogram is deprecated, replaced by Histogram points using double-
+// valued exemplars.
+message IntHistogram {
+  option deprecated = true;
+
+  repeated IntHistogramDataPoint data_points = 1;
+
+  // aggregation_temporality describes if the aggregator reports delta changes
+  // since last report time, or cumulative changes since a fixed start time.
+  AggregationTemporality aggregation_temporality = 2;
+}
+
+// IntExemplar is deprecated. Use Exemplar with as_int for value
+message IntExemplar {
+  option deprecated = true;
+
+  // The set of labels that were filtered out by the aggregator, but recorded
+  // alongside the original measurement. Only labels that were filtered out
+  // by the aggregator should be included
+  repeated opentelemetry.proto.common.v1.StringKeyValue filtered_labels = 1;
+
+  // time_unix_nano is the exact time when this exemplar was recorded
+  //
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+  // 1970.
+  fixed64 time_unix_nano = 2;
+
+  // Numerical int value of the measurement that was recorded.
+  sfixed64 value = 3;
 
   // (Optional) Span ID of the exemplar trace.
   // span_id may be missing if the measurement is not recorded inside a trace

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -166,8 +166,6 @@ message ScopeMetrics {
 // when the start time is truly unknown, setting StartTimeUnixNano is
 // strongly encouraged.
 message Metric {
-  reserved 4, 6, 8;
-
   // name of the metric.
   string name = 1;
 
@@ -182,8 +180,28 @@ message Metric {
   // reported value type for the data points, as well as the relatationship to
   // the time interval over which they are reported.
   oneof data {
+    // IntGauge and IntSum are deprecated and will be removed soon.
+    // 1. Old senders and receivers that are not aware of this change will
+    // continue using the `int_gauge` and `int_sum` fields.
+    // 2. New senders, which are aware of this change MUST send only `gauge`
+    // and `sum` fields.
+    // 3. New receivers, which are aware of this change MUST convert these into
+    // `gauge` and `sum` by using the provided as_int field in the oneof values.
+    // This field will be removed in ~3 months, on July 1, 2021.
+    IntGauge int_gauge = 4 [deprecated = true];
     Gauge gauge = 5;
+    // This field will be removed in ~3 months, on July 1, 2021.
+    IntSum int_sum = 6 [deprecated = true];
     Sum sum = 7;
+
+    // IntHistogram is deprecated and will be removed soon.
+    // 1. Old senders and receivers that are not aware of this change will
+    // continue using the `int_histogram` field.
+    // 2. New senders, which are aware of this change MUST send only `histogram`.
+    // 3. New receivers, which are aware of this change MUST convert this into
+    // `histogram` by simply converting all int64 values into float.
+    // This field will be removed in ~3 months, on July 1, 2021.
+    IntHistogram int_histogram = 8 [deprecated = true];
     Histogram histogram = 9;
     ExponentialHistogram exponential_histogram = 10;
     Summary summary = 11;
@@ -349,13 +367,21 @@ enum DataPointFlags {
 // NumberDataPoint is a single data point in a timeseries that describes the
 // time-varying scalar value of a metric.
 message NumberDataPoint {
-  reserved 1;
-
   // The set of key/value pairs that uniquely identify the timeseries from
   // where this point belongs. The list may be empty (may contain 0 elements).
   // Attribute keys MUST be unique (it is not allowed to have more than one
   // attribute with the same key).
   repeated opentelemetry.proto.common.v1.KeyValue attributes = 7;
+
+  // Labels is deprecated and will be removed soon.
+  // 1. Old senders and receivers that are not aware of this change will
+  // continue using the `labels` field.
+  // 2. New senders, which are aware of this change MUST send only `attributes`.
+  // 3. New receivers, which are aware of this change MUST convert this into
+  // `labels` by simply converting all int64 values into float.
+  //
+  // This field will be removed in ~3 months, on July 1, 2021.
+  repeated opentelemetry.proto.common.v1.StringKeyValue labels = 1 [deprecated = true];
 
   // StartTimeUnixNano is optional but strongly encouraged, see the
   // the detailed comments above Metric.
@@ -397,13 +423,21 @@ message NumberDataPoint {
 // "explicit_bounds" and "bucket_counts" must be omitted and only "count" and
 // "sum" are known.
 message HistogramDataPoint {
-  reserved 1;
-
   // The set of key/value pairs that uniquely identify the timeseries from
   // where this point belongs. The list may be empty (may contain 0 elements).
   // Attribute keys MUST be unique (it is not allowed to have more than one
   // attribute with the same key).
   repeated opentelemetry.proto.common.v1.KeyValue attributes = 9;
+
+  // Labels is deprecated and will be removed soon.
+  // 1. Old senders and receivers that are not aware of this change will
+  // continue using the `labels` field.
+  // 2. New senders, which are aware of this change MUST send only `attributes`.
+  // 3. New receivers, which are aware of this change MUST convert this into
+  // `labels` by simply converting all int64 values into float.
+  //
+  // This field will be removed in ~3 months, on July 1, 2021.
+  repeated opentelemetry.proto.common.v1.StringKeyValue labels = 1 [deprecated = true];
 
   // StartTimeUnixNano is optional but strongly encouraged, see the
   // the detailed comments above Metric.
@@ -591,13 +625,21 @@ message ExponentialHistogramDataPoint {
 // SummaryDataPoint is a single data point in a timeseries that describes the
 // time-varying values of a Summary metric.
 message SummaryDataPoint {
-  reserved 1;
-
   // The set of key/value pairs that uniquely identify the timeseries from
   // where this point belongs. The list may be empty (may contain 0 elements).
   // Attribute keys MUST be unique (it is not allowed to have more than one
   // attribute with the same key).
   repeated opentelemetry.proto.common.v1.KeyValue attributes = 7;
+
+  // Labels is deprecated and will be removed soon.
+  // 1. Old senders and receivers that are not aware of this change will
+  // continue using the `labels` field.
+  // 2. New senders, which are aware of this change MUST send only `attributes`.
+  // 3. New receivers, which are aware of this change MUST convert this into
+  // `labels` by simply converting all int64 values into float.
+  //
+  // This field will be removed in ~3 months, on July 1, 2021.
+  repeated opentelemetry.proto.common.v1.StringKeyValue labels = 1 [deprecated = true];
 
   // StartTimeUnixNano is optional but strongly encouraged, see the
   // the detailed comments above Metric.
@@ -658,12 +700,21 @@ message SummaryDataPoint {
 // was recorded, for example the span and trace ID of the active span when the
 // exemplar was recorded.
 message Exemplar {
-  reserved 1;
-
   // The set of key/value pairs that were filtered out by the aggregator, but
   // recorded alongside the original measurement. Only key/value pairs that were
   // filtered out by the aggregator should be included
   repeated opentelemetry.proto.common.v1.KeyValue filtered_attributes = 7;
+
+  // Labels is deprecated and will be removed soon.
+  // 1. Old senders and receivers that are not aware of this change will
+  // continue using the `filtered_labels` field.
+  // 2. New senders, which are aware of this change MUST send only
+  // `filtered_attributes`.
+  // 3. New receivers, which are aware of this change MUST convert this into
+  // `filtered_labels` by simply converting all int64 values into float.
+  //
+  // This field will be removed in ~3 months, on July 1, 2021.
+  repeated opentelemetry.proto.common.v1.StringKeyValue filtered_labels = 1 [deprecated = true];
 
   // time_unix_nano is the exact time when this exemplar was recorded
   //
@@ -678,6 +729,159 @@ message Exemplar {
     double as_double = 3;
     sfixed64 as_int = 6;
   }
+
+  // (Optional) Span ID of the exemplar trace.
+  // span_id may be missing if the measurement is not recorded inside a trace
+  // or if the trace is not sampled.
+  bytes span_id = 4;
+
+  // (Optional) Trace ID of the exemplar trace.
+  // trace_id may be missing if the measurement is not recorded inside a trace
+  // or if the trace is not sampled.
+  bytes trace_id = 5;
+}
+
+//
+// Move deprecated messages below this line
+//
+
+// IntDataPoint is deprecated. Use integer value in NumberDataPoint.
+message IntDataPoint {
+  option deprecated = true;
+
+  // The set of labels that uniquely identify this timeseries.
+  repeated opentelemetry.proto.common.v1.StringKeyValue labels = 1;
+
+  // StartTimeUnixNano is optional but strongly encouraged, see the
+  // the detailed comments above Metric.
+  //
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+  // 1970.
+  fixed64 start_time_unix_nano = 2;
+
+  // TimeUnixNano is required, see the detailed comments above Metric.
+  //
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+  // 1970.
+  fixed64 time_unix_nano = 3;
+
+  // value itself.
+  sfixed64 value = 4;
+
+  // (Optional) List of exemplars collected from
+  // measurements that were used to form the data point
+  repeated IntExemplar exemplars = 5;
+}
+
+// IntGauge is deprecated.  Use Gauge with an integer value in NumberDataPoint.
+message IntGauge {
+  option deprecated = true;
+
+  repeated IntDataPoint data_points = 1;
+}
+
+// IntSum is deprecated.  Use Sum with an integer value in NumberDataPoint.
+message IntSum {
+  option deprecated = true;
+
+  repeated IntDataPoint data_points = 1;
+
+  // aggregation_temporality describes if the aggregator reports delta changes
+  // since last report time, or cumulative changes since a fixed start time.
+  AggregationTemporality aggregation_temporality = 2;
+
+  // If "true" means that the sum is monotonic.
+  bool is_monotonic = 3;
+}
+
+// IntHistogramDataPoint is deprecated; use HistogramDataPoint.
+message IntHistogramDataPoint {
+  option deprecated = true;
+
+  // The set of labels that uniquely identify this timeseries.
+  repeated opentelemetry.proto.common.v1.StringKeyValue labels = 1;
+
+  // StartTimeUnixNano is optional but strongly encouraged, see the
+  // the detailed comments above Metric.
+  //
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+  // 1970.
+  fixed64 start_time_unix_nano = 2;
+
+  // TimeUnixNano is required, see the detailed comments above Metric.
+  //
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+  // 1970.
+  fixed64 time_unix_nano = 3;
+
+  // count is the number of values in the population. Must be non-negative. This
+  // value must be equal to the sum of the "count" fields in buckets if a
+  // histogram is provided.
+  fixed64 count = 4;
+
+  // sum of the values in the population. If count is zero then this field
+  // must be zero. This value must be equal to the sum of the "sum" fields in
+  // buckets if a histogram is provided.
+  sfixed64 sum = 5;
+
+  // bucket_counts is an optional field contains the count values of histogram
+  // for each bucket.
+  //
+  // The sum of the bucket_counts must equal the value in the count field.
+  //
+  // The number of elements in bucket_counts array must be by one greater than
+  // the number of elements in explicit_bounds array.
+  repeated fixed64 bucket_counts = 6;
+
+  // explicit_bounds specifies buckets with explicitly defined bounds for values.
+  //
+  // The boundaries for bucket at index i are:
+  //
+  // (-infinity, explicit_bounds[i]] for i == 0
+  // (explicit_bounds[i-1], explicit_bounds[i]] for 0 < i < size(explicit_bounds)
+  // (explicit_bounds[i-1], +infinity) for i == size(explicit_bounds)
+  //
+  // The values in the explicit_bounds array must be strictly increasing.
+  //
+  // Histogram buckets are inclusive of their upper boundary, except the last
+  // bucket where the boundary is at infinity. This format is intentionally
+  // compatible with the OpenMetrics histogram definition.
+  repeated double explicit_bounds = 7;
+
+  // (Optional) List of exemplars collected from
+  // measurements that were used to form the data point
+  repeated IntExemplar exemplars = 8;
+}
+
+// IntHistogram is deprecated, replaced by Histogram points using double-
+// valued exemplars.
+message IntHistogram {
+  option deprecated = true;
+
+  repeated IntHistogramDataPoint data_points = 1;
+
+  // aggregation_temporality describes if the aggregator reports delta changes
+  // since last report time, or cumulative changes since a fixed start time.
+  AggregationTemporality aggregation_temporality = 2;
+}
+
+// IntExemplar is deprecated. Use Exemplar with as_int for value
+message IntExemplar {
+  option deprecated = true;
+
+  // The set of labels that were filtered out by the aggregator, but recorded
+  // alongside the original measurement. Only labels that were filtered out
+  // by the aggregator should be included
+  repeated opentelemetry.proto.common.v1.StringKeyValue filtered_labels = 1;
+
+  // time_unix_nano is the exact time when this exemplar was recorded
+  //
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+  // 1970.
+  fixed64 time_unix_nano = 2;
+
+  // Numerical int value of the measurement that was recorded.
+  sfixed64 value = 3;
 
   // (Optional) Span ID of the exemplar trace.
   // span_id may be missing if the measurement is not recorded inside a trace


### PR DESCRIPTION
## Which problem is this PR solving?

Updates OpenTelemetry proto definitions to v1.3.1

## Short description of the changes

Pulls upstream changes up to v1.3.1.